### PR TITLE
Fix favicon path in robots page

### DIFF
--- a/robots.html
+++ b/robots.html
@@ -26,8 +26,8 @@
 
         <!-- icon-, tab- and mobile-related things (probably don't touch) -->
         <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png">
-        <link rel="icon" type="image/png" sizes="32x32" href="images/images/favicon-32x32.png">
-        <link rel="icon" type="image/png" sizes="16x16" href="images/images/favicon-16x16.png">
+        <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
+        <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png">
         <link rel="manifest" href="site.webmanifest">
         <link rel="mask-icon" href="safari-pinned-tab.svg" color="#007b9e">
         <meta name="msapplication-TileColor" content="#2b5797">


### PR DESCRIPTION
## Summary
- fix favicon paths in robots.html to remove duplicated `images/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68662e713d108325b7f5f772d5f0e229