### PR TITLE
Remove Best Buy and Generac logos from sponsors

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,21 +118,13 @@
       
       <!-- this is the top row of sponsors. bootstrap spaces things horizontally in terms of portions of a column (up to 12), so if i want 3 columns to fill the screen i have to use 4 column portions per column ("col-4"; the "-sm" is a breakpoint which makes it display like this only on screens larger than "sm") -->
       <div class="row">
-        <div class="col-sm-3 my-3 my-sm-0">
+        <div class="col-sm-6 my-3 my-sm-0">
           <a class="h-100 d-flex justify-content-center align-items-center" href="https://www.hatch.com/"
           target="_blank"><img class="img-fluid" src="images/sponsors_hatch.png" /></a>
         </div>
-        <div class="col-sm-3 my-3 my-sm-0">
-          <a class="h-100 d-flex justify-content-center align-items-center" href="https://www.bestbuy.ca/en-ca"
-            target="_blank"><img class="img-fluid" src="images/sponsors_best_buy.png" /></a>
-        </div>
-        <div class="col-sm-3 my-3 my-sm-0">
+        <div class="col-sm-6 my-3 my-sm-0">
           <a class="h-100 d-flex justify-content-center align-items-center" href="https://www.firstinspires.org/"
           target="_blank"><img class="img-fluid" src="images/sponsors_first.png" /></a>
-        </div>
-        <div class="col-sm-3 my-3 my-sm-0">
-          <a class="h-100 d-flex justify-content-center align-items-center" href="https://www.generac.com/"
-          target="_blank"><img class="img-fluid" src="images/sponsors_generac.png" /></a>
         </div>
       </div>
       <!-- this smaller hr inherits the properties of the larger one but shrinks the width to 50 px -->


### PR DESCRIPTION
## Summary
- remove the Best Buy and Generac sponsor listings from the homepage
- adjust the top sponsor row to two columns to keep spacing balanced

## Testing
- not run (static HTML change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928a675bc488325b77870205794dc1d)