### PR TITLE
Adjust sponsor logo sizing

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -173,3 +173,9 @@ h7 {
   max-width: 100%;
   width: auto;
 }
+
+.sponsor-logo-large {
+  max-height: 160px;
+  max-width: 100%;
+  width: auto;
+}

--- a/index.html
+++ b/index.html
@@ -120,11 +120,11 @@
       <div class="row">
         <div class="col-sm-6 my-3 my-sm-0">
           <a class="h-100 d-flex justify-content-center align-items-center" href="https://www.hatch.com/"
-          target="_blank"><img class="img-fluid" src="images/sponsors_hatch.png" /></a>
+          target="_blank"><img class="img-fluid sponsor-logo-large" src="images/sponsors_hatch.png" /></a>
         </div>
         <div class="col-sm-6 my-3 my-sm-0">
           <a class="h-100 d-flex justify-content-center align-items-center" href="https://www.firstinspires.org/"
-          target="_blank"><img class="img-fluid" src="images/sponsors_first.png" /></a>
+          target="_blank"><img class="img-fluid sponsor-logo-large" src="images/sponsors_first.png" /></a>
         </div>
       </div>
       <!-- this smaller hr inherits the properties of the larger one but shrinks the width to 50 px -->


### PR DESCRIPTION
## Summary
- add a reusable large sponsor logo class to constrain image height
- apply the new sizing to the Hatch and FIRST sponsor logos on the home page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928aa86a81083259beab7af034c3463)