### PR TITLE
Improve sponsor logo scaling

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -168,14 +168,26 @@ h7 {
   font-size: 50px;
 }
 
-.sponsor-logo-medium {
-  max-height: 120px;
+.sponsor-logo {
   max-width: 100%;
   width: auto;
+  height: auto;
+  object-fit: contain;
+  max-height: clamp(90px, 12vw, 180px);
+}
+
+.sponsor-logo-hero {
+  max-height: clamp(160px, 22vw, 260px);
 }
 
 .sponsor-logo-large {
-  max-height: 160px;
-  max-width: 100%;
-  width: auto;
+  max-height: clamp(140px, 18vw, 220px);
+}
+
+.sponsor-logo-medium {
+  max-height: clamp(110px, 14vw, 180px);
+}
+
+.sponsor-logo-small {
+  max-height: clamp(90px, 12vw, 150px);
 }

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
       <hr class="rainstorms-divider mb-5" />
       <div>
         <a class="h-100 d-flex justify-content-center align-items-center" href="https://www.friendlyfuture.com/en/foundation"
-        target="_blank"><img class="img-fluid" src="images/sponsors_TELUS_Foundation_TFFF_EN_Partner_2022_Digital_RGB.png" width="600" height="700" /></a>
+        target="_blank"><img class="img-fluid sponsor-logo sponsor-logo-hero" src="images/sponsors_TELUS_Foundation_TFFF_EN_Partner_2022_Digital_RGB.png" /></a>
       </div>
       <hr class="rainstorms-divider rainstorms-divider-small" />
       
@@ -120,11 +120,11 @@
       <div class="row">
         <div class="col-sm-6 my-3 my-sm-0">
           <a class="h-100 d-flex justify-content-center align-items-center" href="https://www.hatch.com/"
-          target="_blank"><img class="img-fluid sponsor-logo-large" src="images/sponsors_hatch.png" /></a>
+          target="_blank"><img class="img-fluid sponsor-logo sponsor-logo-large" src="images/sponsors_hatch.png" /></a>
         </div>
         <div class="col-sm-6 my-3 my-sm-0">
           <a class="h-100 d-flex justify-content-center align-items-center" href="https://www.firstinspires.org/"
-          target="_blank"><img class="img-fluid sponsor-logo-large" src="images/sponsors_first.png" /></a>
+          target="_blank"><img class="img-fluid sponsor-logo sponsor-logo-large" src="images/sponsors_first.png" /></a>
         </div>
       </div>
       <!-- this smaller hr inherits the properties of the larger one but shrinks the width to 50 px -->
@@ -134,19 +134,19 @@
       <div class="row">
         <div class="col-sm-3 my-3 my-sm-0">
           <a class="h-100 d-flex justify-content-center align-items-center" href="https://www.haascnc.com/index.html"
-          target="_blank"><img class="img-fluid sponsor-logo-medium" src="images/sponsors_gene_haas.png" /></a>
+          target="_blank"><img class="img-fluid sponsor-logo sponsor-logo-medium" src="images/sponsors_gene_haas.png" /></a>
         </div>
         <div class="col-sm-3 my-3 my-sm-0">
           <a class="h-100 d-flex justify-content-center align-items-center" href="https://www.templetonpac.com/about-the-pac.html"
-          target="_blank"><img class="img-fluid sponsor-logo-medium" src="images/sponsors_templeton_PAC.png" /></a>
+          target="_blank"><img class="img-fluid sponsor-logo sponsor-logo-medium" src="images/sponsors_templeton_PAC.png" /></a>
         </div>
         <div class="col-sm-3 my-3 my-sm-0">
           <a class="h-100 d-flex justify-content-center align-items-center" href="https://kirke-consulting.com/"
-          target="_blank"><img class="img-fluid sponsor-logo-medium" src="images/sponsors_kirke.png"/></a>
+          target="_blank"><img class="img-fluid sponsor-logo sponsor-logo-medium" src="images/sponsors_kirke.png"/></a>
         </div>
         <div class="col-sm-3 my-3 my-sm-0">
           <a class="h-100 d-flex justify-content-center align-items-center" href="https://www.bgcengineering.ca/"
-          target="_blank"><img class="img-fluid sponsor-logo-medium" src="images/sponsors_BGC.png" /></a>
+          target="_blank"><img class="img-fluid sponsor-logo sponsor-logo-medium" src="images/sponsors_BGC.png" /></a>
         </div>
       </div>
       <hr class="rainstorms-divider rainstorms-divider-small" />
@@ -154,15 +154,15 @@
       <div class="row">
         <div class="col-sm-3 my-3 my-sm-0">
           <a class="h-100 d-flex justify-content-center align-items-center" href="https://fittererelectric.com/"
-          target="_blank"><img class="img-fluid" src="images/sponsors_fitterer_electric.png" /></a>
+          target="_blank"><img class="img-fluid sponsor-logo sponsor-logo-small" src="images/sponsors_fitterer_electric.png" /></a>
         </div>
         <div class="col-sm-3 my-3 my-sm-0">
           <a class="h-100 d-flex justify-content-center align-items-center" href="https://cimsltd.com/"
-          target="_blank"><img class="img-fluid" src="images/sponsors_CIMS_ltd.png" /></a>
+          target="_blank"><img class="img-fluid sponsor-logo sponsor-logo-small" src="images/sponsors_CIMS_ltd.png" /></a>
         </div>
         <div class="col-sm-3 my-3 my-sm-0">
           <a class="h-100 d-flex justify-content-center align-items-center" href="https://www.motorola.ca/"
-          target="_blank"><img class="img-fluid" src="images/sponsors_motorola.png" /></a>
+          target="_blank"><img class="img-fluid sponsor-logo sponsor-logo-small" src="images/sponsors_motorola.png" /></a>
         </div>
         <div class="col-sm-3 my-3">
           <h3>Alejandra Brown</h3>


### PR DESCRIPTION
## Summary
- add responsive sponsor logo sizing with clamp-based CSS helper classes
- apply shared sponsor logo styling across all sponsor images on the homepage

## Testing
- not run (static site change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928ab9490e88325b6907dc51e5d3560)